### PR TITLE
Add test scaffolding

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,6 @@ script:
 
 notifications:
   irc: "irc.freenode.org#islandora"
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Build Status](https://travis-ci.org/Islandora-CLAW/pdx.svg?branch=master)](https://travis-ci.org/Islandora-CLAW/pdx)
 [![Contribution Guidelines](http://img.shields.io/badge/CONTRIBUTING-Guidelines-blue.svg)](./CONTRIBUTING.md)
 [![LICENSE](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](./LICENSE)
+[![codecov](https://codecov.io/gh/Islandora-CLAW/pdx/branch/master/graph/badge.svg)](https://codecov.io/gh/Islandora-CLAW/pdx)
 
 This is a top level container for the various PCDM related Islandora CLAW microservices. It allows you to mount the various endpoints at one port on one machine and makes a development vagrant/docker configuration easier to produce.
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<phpunit bootstrap="./test/bootstrap.php"
+    colors="true">
+    <testsuites>
+        <testsuite name="PDX">
+            <directory>test</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/test/PdxWebTestCase.php
+++ b/test/PdxWebTestCase.php
@@ -14,7 +14,7 @@ class PdxWebTestCase extends WebTestCase
 
   public function createApplication()
   {
-    return (require __DIR__.'/../src/app.php');
+
   }
 
 

--- a/test/PdxWebTestCase.php
+++ b/test/PdxWebTestCase.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Islandora\Pdx;
+
+use Silex\WebTestCase;
+use Islandora\Chullo\Uuid\UuidGenerator;
+
+class PdxWebTestCase extends WebTestCase
+{
+  public function __construct()
+  {
+    
+  }
+
+  public function createApplication()
+  {
+    return (require __DIR__.'/../src/app.php');
+  }
+
+
+}

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -1,0 +1,4 @@
+<?php
+    include_once __DIR__ . '/../vendor/autoload.php'; // composer autoload
+    include_once __DIR__ . '/PdxWebTestCase.php'; // Common application functions
+


### PR DESCRIPTION
This PR adds:
- PHPUnit scaffolding (phpunit.xml.dist file and /test/bootstrap.php, enough to get the PHPUnit CLI test runner to execute with 0 tests)
- Codecov.io integration (.travis.yml `after_success` hook and README badge)

This is a stab towards resolving #260 and #280.
